### PR TITLE
Issue 795 Term of service

### DIFF
--- a/ui/dashboard/src/components/TermsOfService.vue
+++ b/ui/dashboard/src/components/TermsOfService.vue
@@ -16,7 +16,7 @@ import { ref } from "@vue/reactivity";
 import { computed, watch } from "@vue/runtime-core";
 import Modal from "@/components/Modal";
 import Loading from "@/components/Loading";
-import marked from "marked";
+import { marked } from "marked";
 import { useStore } from "vuex";
 
 export default {


### PR DESCRIPTION
I just notice that the Term of service modal (#795) is not loading because of the `marked` call. It's look like the latest version of `marked` update the API, this pull request will get it fixed!