### PR TITLE
PWA caching issue

### DIFF
--- a/ui/dashboard/src/registerServiceWorker.js
+++ b/ui/dashboard/src/registerServiceWorker.js
@@ -20,7 +20,8 @@ if (process.env.NODE_ENV === 'production') {
       console.log('New content is downloading.')
     },
     updated () {
-      console.log('New content is available; please refresh.')
+      alert('New content is available; please refresh.')
+      window.location.reload()
     },
     offline () {
       console.log('No internet connection found. App is running in offline mode.')

--- a/ui/dashboard/src/registerServiceWorker.js
+++ b/ui/dashboard/src/registerServiceWorker.js
@@ -4,29 +4,29 @@ import { register } from 'register-service-worker'
 
 if (process.env.NODE_ENV === 'production') {
   register(`${process.env.BASE_URL}service-worker.js`, {
-    ready () {
+    ready() {
       console.log(
         'App is being served from cache by a service worker.\n' +
         'For more details, visit https://goo.gl/AFskqB'
       )
     },
-    registered () {
+    registered() {
       console.log('Service worker has been registered.')
     },
-    cached () {
+    cached() {
       console.log('Content has been cached for offline use.')
     },
-    updatefound () {
+    updatefound() {
       console.log('New content is downloading.')
     },
-    updated () {
-      alert('New content is available; please refresh.')
+    updated() {
+      alert('A newer version of UpStage have been released! Please refresh the page to update!')
       window.location.reload()
     },
-    offline () {
+    offline() {
       console.log('No internet connection found. App is running in offline mode.')
     },
-    error (error) {
+    error(error) {
       console.error('Error during service worker registration:', error)
     }
   })

--- a/ui/dashboard/vue.config.js
+++ b/ui/dashboard/vue.config.js
@@ -12,6 +12,9 @@ module.exports = {
         name: "UpStage",
         themeColor: "#30ac45",
         msTileColor: "#ffffff",
-        manifestCrossorigin: "use-credentials"
+        manifestCrossorigin: "use-credentials",
+        workboxOptions: {
+            skipWaiting: true
+        }
     }
 }


### PR DESCRIPTION
I just realize that the default Vue PWA plugin that we're using only provide the scaffolded interface. We still need to implement the cache invalidating ourself. This pull request will show a dialog to the user whenever a new version is released: `A newer version of UpStage have been released! Please refresh the page to update!` and it will automatically reload the page then load the latest version, without them having to do a fresh reload (Ctrl+F5) every time 😅 